### PR TITLE
MF286R: fix model detection

### DIFF
--- a/atc-zte-mf286r/files/lib/netifd/proto/atc.sh
+++ b/atc-zte-mf286r/files/lib/netifd/proto/atc.sh
@@ -283,7 +283,7 @@ proto_atc_setup () {
         echo $model
         echo $fw
     }
-    if [ -n "$(echo "$manufactor" | grep 'Marwell')" ] && [ -n "$(echo "$model" | grep 'MF286R')" ]
+    if [ -n "$(echo "$manufactor" | grep 'Marwell')" ] && [ -n "$(echo "$model" | grep 'LINUX')" ] && [ -n "$(echo "$fw" | grep 'MF286')" ] 
     then
         :
     else


### PR DESCRIPTION
On this device, the model reported by the model is "LINUX", but the string "MF286" appears in the firmware version, so use it as well as model verification step.